### PR TITLE
Closes #8 Fix: Restore index pointer integrity in the BAM-to-parquet engine

### DIFF
--- a/__code6/CakeNumbersSequence.cs
+++ b/__code6/CakeNumbersSequence.cs
@@ -1,0 +1,27 @@
+namespace Algorithms.Sequences;
+
+/// <summary>
+///     <para>
+///         Cake numbers: maximal number of pieces resulting from n planar cuts through a cube
+///         (or cake): C(n+1,3) + n + 1.
+///     </para>
+///     <para>
+///         OEIS: https://oeis.org/A000125.
+///     </para>
+/// </summary>
+public class CakeNumbersSequence : ISequence
+{
+    public IEnumerable<BigInteger> Sequence
+    {
+        get
+        {
+            var n = new BigInteger(0);
+            while (true)
+            {
+                var next = (BigInteger.Pow(n, 3) + 5 * n + 6) / 6;
+                n++;
+                yield return next;
+            }
+        }
+    }
+}

--- a/__code6/DecimalToBinary.test.js
+++ b/__code6/DecimalToBinary.test.js
@@ -1,0 +1,26 @@
+import { decimalToBinary } from '../DecimalToBinary'
+
+test('The Binary representation of 35 is 100011', () => {
+  const res = decimalToBinary(35)
+  expect(res).toBe('100011')
+})
+
+test('The Binary representation of 1 is 1', () => {
+  const res = decimalToBinary(1)
+  expect(res).toBe('1')
+})
+
+test('The Binary representation of 1000 is 1111101000', () => {
+  const res = decimalToBinary(1000)
+  expect(res).toBe('1111101000')
+})
+
+test('The Binary representation of 2 is 10', () => {
+  const res = decimalToBinary(2)
+  expect(res).toBe('10')
+})
+
+test('The Binary representation of 17 is 10001', () => {
+  const res = decimalToBinary(17)
+  expect(res).toBe('10001')
+})

--- a/__code6/DistanceBetweenTwoPoints.java
+++ b/__code6/DistanceBetweenTwoPoints.java
@@ -1,0 +1,33 @@
+package com.thealgorithms.maths;
+
+/**
+ * Distance Between Two Points in 2D Space.
+ *
+ * <p>This class provides a method to calculate the Euclidean distance between two points in a
+ * two-dimensional plane.
+ *
+ * <p>Formula: d = sqrt((x2 - x1)^2 + (y2 - y1)^2)
+ *
+ * <p>Reference: https://en.wikipedia.org/wiki/Euclidean_distance
+ */
+public final class DistanceBetweenTwoPoints {
+
+    private DistanceBetweenTwoPoints() {
+        // Utility class; prevent instantiation
+    }
+
+    /**
+     * Calculate the Euclidean distance between two points.
+     *
+     * @param x1 x-coordinate of the first point
+     * @param y1 y-coordinate of the first point
+     * @param x2 x-coordinate of the second point
+     * @param y2 y-coordinate of the second point
+     * @return Euclidean distance between the two points
+     */
+    public static double calculate(final double x1, final double y1, final double x2, final double y2) {
+        final double deltaX = x2 - x1;
+        final double deltaY = y2 - y1;
+        return Math.sqrt(deltaX * deltaX + deltaY * deltaY);
+    }
+}

--- a/__code6/NumberOfPrimesByNumberOfDigitsSequence.cs
+++ b/__code6/NumberOfPrimesByNumberOfDigitsSequence.cs
@@ -1,0 +1,41 @@
+namespace Algorithms.Sequences;
+
+/// <summary>
+///     <para>
+///         Number of primes with n digits
+///         (The number of primes between 10^(n-1) and 10^n).
+///     </para>
+///     <para>
+///         Wikipedia: https://wikipedia.org/wiki/Prime-counting_function.
+///     </para>
+///     <para>
+///         OEIS: https://oeis.org/A006879.
+///     </para>
+/// </summary>
+public class NumberOfPrimesByNumberOfDigitsSequence : ISequence
+{
+    /// <summary>
+    /// Gets sequence of number of primes.
+    /// </summary>
+    public IEnumerable<BigInteger> Sequence
+    {
+        get
+        {
+            ISequence primes = new PrimesSequence();
+            var powerOf10 = new BigInteger(1);
+            var counter = new BigInteger(0);
+
+            foreach (var p in primes.Sequence)
+            {
+                if (p > powerOf10)
+                {
+                    yield return counter;
+                    counter = 0;
+                    powerOf10 *= 10;
+                }
+
+                counter++;
+            }
+        }
+    }
+}

--- a/__code6/README.md
+++ b/__code6/README.md
@@ -1,0 +1,9 @@
+# Audio Filter
+
+Audio filters work on the frequency of an audio signal to attenuate unwanted frequency and amplify wanted ones.
+They are used within anything related to sound, whether it is radio communication or a hi-fi system.
+
+* <https://www.masteringbox.com/filter-types/>
+* <http://ethanwiner.com/filters.html>
+* <https://en.wikipedia.org/wiki/Audio_filter>
+* <https://en.wikipedia.org/wiki/Electronic_filter>

--- a/__code6/cycle_check_directed_graph.cpp
+++ b/__code6/cycle_check_directed_graph.cpp
@@ -1,0 +1,314 @@
+/**
+ * @file cycle_check_directed graph.cpp
+ *
+ * @brief BFS and DFS algorithms to check for cycle in a directed graph.
+ *
+ * @author [Anmol3299](mailto:mittalanmol22@gmail.com)
+ *
+ */
+
+#include <cstdint>
+#include <iostream>     // for std::cout
+#include <map>          // for std::map
+#include <queue>        // for std::queue
+#include <stdexcept>    // for throwing errors
+#include <type_traits>  // for std::remove_reference
+#include <utility>      // for std::move
+#include <vector>       // for std::vector
+
+/**
+ * Implementation of non-weighted directed edge of a graph.
+ *
+ * The source vertex of the edge is labelled "src" and destination vertex is
+ * labelled "dest".
+ */
+struct Edge {
+    unsigned int src;
+    unsigned int dest;
+
+    Edge() = delete;
+    ~Edge() = default;
+    Edge(Edge&&) = default;
+    Edge& operator=(Edge&&) = default;
+    Edge(Edge const&) = default;
+    Edge& operator=(Edge const&) = default;
+
+    /** Set the source and destination of the vertex.
+     *
+     * @param source is the source vertex of the edge.
+     * @param destination is the destination vertex of the edge.
+     */
+    Edge(unsigned int source, unsigned int destination)
+        : src(source), dest(destination) {}
+};
+
+using AdjList = std::map<unsigned int, std::vector<unsigned int>>;
+
+/**
+ * Implementation of graph class.
+ *
+ * The graph will be represented using Adjacency List representation.
+ * This class contains 2 data members "m_vertices" & "m_adjList" used to
+ * represent the number of vertices and adjacency list of the graph
+ * respectively. The vertices are labelled 0 - (m_vertices - 1).
+ */
+class Graph {
+ public:
+    Graph() : m_adjList({}) {}
+    ~Graph() = default;
+    Graph(Graph&&) = default;
+    Graph& operator=(Graph&&) = default;
+    Graph(Graph const&) = default;
+    Graph& operator=(Graph const&) = default;
+
+    /** Create a graph from vertices and adjacency list.
+     *
+     * @param vertices specify the number of vertices the graph would contain.
+     * @param adjList is the adjacency list representation of graph.
+     */
+    Graph(unsigned int vertices, AdjList adjList)
+        : m_vertices(vertices), m_adjList(std::move(adjList)) {}
+
+    /** Create a graph from vertices and adjacency list.
+     *
+     * @param vertices specify the number of vertices the graph would contain.
+     * @param adjList is the adjacency list representation of graph.
+     */
+    Graph(unsigned int vertices, AdjList&& adjList)
+        : m_vertices(vertices), m_adjList(std::move(adjList)) {}
+
+    /** Create a graph from vertices and a set of edges.
+     *
+     * Adjacency list of the graph would be created from the set of edges. If
+     * the source or destination of any edge has a value greater or equal to
+     * number of vertices, then it would throw a range_error.
+     *
+     * @param vertices specify the number of vertices the graph would contain.
+     * @param edges is a vector of edges.
+     */
+    Graph(unsigned int vertices, std::vector<Edge> const& edges)
+        : m_vertices(vertices) {
+        for (auto const& edge : edges) {
+            if (edge.src >= vertices || edge.dest >= vertices) {
+                throw std::range_error(
+                    "Either src or dest of edge out of range");
+            }
+            m_adjList[edge.src].emplace_back(edge.dest);
+        }
+    }
+
+    /** Return a const reference of the adjacency list.
+     *
+     * @return const reference to the adjacency list
+     */
+    std::remove_reference<AdjList>::type const& getAdjList() const {
+        return m_adjList;
+    }
+
+    /**
+     * @return number of vertices in the graph.
+     */
+    unsigned int getVertices() const { return m_vertices; }
+
+    /** Add vertices in the graph.
+     *
+     * @param num is the number of vertices to be added. It adds 1 vertex by
+     * default.
+     *
+     */
+    void addVertices(unsigned int num = 1) { m_vertices += num; }
+
+    /** Add an edge in the graph.
+     *
+     * @param edge that needs to be added.
+     */
+    void addEdge(Edge const& edge) {
+        if (edge.src >= m_vertices || edge.dest >= m_vertices) {
+            throw std::range_error("Either src or dest of edge out of range");
+        }
+        m_adjList[edge.src].emplace_back(edge.dest);
+    }
+
+    /** Add an Edge in the graph
+     *
+     * @param source is source vertex of the edge.
+     * @param destination is the destination vertex of the edge.
+     */
+    void addEdge(unsigned int source, unsigned int destination) {
+        if (source >= m_vertices || destination >= m_vertices) {
+            throw std::range_error(
+                "Either source or destination of edge out of range");
+        }
+        m_adjList[source].emplace_back(destination);
+    }
+
+ private:
+    unsigned int m_vertices = 0;
+    AdjList m_adjList;
+};
+
+/**
+ * Check if a directed graph has a cycle or not.
+ *
+ * This class provides 2 methods to check for cycle in a directed graph:
+ * isCyclicDFS & isCyclicBFS.
+ *
+ * - isCyclicDFS uses DFS traversal method to check for cycle in a graph.
+ * - isCyclidBFS used BFS traversal method to check for cycle in a graph.
+ */
+class CycleCheck {
+ private:
+    enum nodeStates : uint8_t { not_visited = 0, in_stack, visited };
+
+    /** Helper function of "isCyclicDFS".
+     *
+     * @param adjList is the adjacency list representation of some graph.
+     * @param state is the state of the nodes of the graph.
+     * @param node is the node being evaluated.
+     *
+     * @return true if graph has a cycle, else false.
+     */
+    static bool isCyclicDFSHelper(AdjList const& adjList,
+                                  std::vector<nodeStates>* state,
+                                  unsigned int node) {
+        // Add node "in_stack" state.
+        (*state)[node] = in_stack;
+
+        // If the node has children, then recursively visit all children of the
+        // node.
+        auto const it = adjList.find(node);
+        if (it != adjList.end()) {
+            for (auto child : it->second) {
+                // If state of child node is "not_visited", evaluate that child
+                // for presence of cycle.
+                auto state_of_child = (*state)[child];
+                if (state_of_child == not_visited) {
+                    if (isCyclicDFSHelper(adjList, state, child)) {
+                        return true;
+                    }
+                } else if (state_of_child == in_stack) {
+                    // If child node was "in_stack", then that means that there
+                    // is a cycle in the graph. Return true for presence of the
+                    // cycle.
+                    return true;
+                }
+            }
+        }
+
+        // Current node has been evaluated for the presence of cycle and had no
+        // cycle. Mark current node as "visited".
+        (*state)[node] = visited;
+        // Return that current node didn't result in any cycles.
+        return false;
+    }
+
+ public:
+    /** Driver function to check if a graph has a cycle.
+     *
+     * This function uses DFS to check for cycle in the graph.
+     *
+     * @param graph which needs to be evaluated for the presence of cycle.
+     * @return true if a cycle is detected, else false.
+     */
+    static bool isCyclicDFS(Graph const& graph) {
+        auto vertices = graph.getVertices();
+
+        /** State of the node.
+         *
+         * It is a vector of "nodeStates" which represents the state node is in.
+         * It can take only 3 values: "not_visited", "in_stack", and "visited".
+         *
+         * Initially, all nodes are in "not_visited" state.
+         */
+        std::vector<nodeStates> state(vertices, not_visited);
+
+        // Start visiting each node.
+        for (unsigned int node = 0; node < vertices; node++) {
+            // If a node is not visited, only then check for presence of cycle.
+            // There is no need to check for presence of cycle for a visited
+            // node as it has already been checked for presence of cycle.
+            if (state[node] == not_visited) {
+                // Check for cycle.
+                if (isCyclicDFSHelper(graph.getAdjList(), &state, node)) {
+                    return true;
+                }
+            }
+        }
+
+        // All nodes have been safely traversed, that means there is no cycle in
+        // the graph. Return false.
+        return false;
+    }
+
+    /** Check if a graph has cycle or not.
+     *
+     * This function uses BFS to check if a graph is cyclic or not.
+     *
+     * @param graph which needs to be evaluated for the presence of cycle.
+     * @return true if a cycle is detected, else false.
+     */
+    static bool isCyclicBFS(Graph const& graph) {
+        auto graphAjdList = graph.getAdjList();
+        auto vertices = graph.getVertices();
+
+        std::vector<unsigned int> indegree(vertices, 0);
+        // Calculate the indegree i.e. the number of incident edges to the node.
+        for (auto const& list : graphAjdList) {
+            auto children = list.second;
+            for (auto const& child : children) {
+                indegree[child]++;
+            }
+        }
+
+        std::queue<unsigned int> can_be_solved;
+        for (unsigned int node = 0; node < vertices; node++) {
+            // If a node doesn't have any input edges, then that node will
+            // definately not result in a cycle and can be visited safely.
+            if (!indegree[node]) {
+                can_be_solved.emplace(node);
+            }
+        }
+
+        // Vertices that need to be traversed.
+        auto remain = vertices;
+        // While there are safe nodes that we can visit.
+        while (!can_be_solved.empty()) {
+            auto solved = can_be_solved.front();
+            // Visit the node.
+            can_be_solved.pop();
+            // Decrease number of nodes that need to be traversed.
+            remain--;
+
+            // Visit all the children of the visited node.
+            auto it = graphAjdList.find(solved);
+            if (it != graphAjdList.end()) {
+                for (auto child : it->second) {
+                    // Check if we can visited the node safely.
+                    if (--indegree[child] == 0) {
+                        // if node can be visited safely, then add that node to
+                        // the visit queue.
+                        can_be_solved.emplace(child);
+                    }
+                }
+            }
+        }
+
+        // If there are still nodes that we can't visit, then it means that
+        // there is a cycle and return true, else return false.
+        return !(remain == 0);
+    }
+};
+
+/**
+ * Main function.
+ */
+int main() {
+    // Instantiate the graph.
+    Graph g(7, std::vector<Edge>{{0, 1}, {1, 2}, {2, 0}, {2, 5}, {3, 5}});
+    // Check for cycle using BFS method.
+    std::cout << CycleCheck::isCyclicBFS(g) << '\n';
+
+    // Check for cycle using DFS method.
+    std::cout << CycleCheck::isCyclicDFS(g) << '\n';
+    return 0;
+}

--- a/__code6/exchangesort.go
+++ b/__code6/exchangesort.go
@@ -1,0 +1,21 @@
+// Implementation of exchange sort algorithm, a variant of bubble sort
+// average time complexity: O(n^2)
+// worst time complexity: O(n^2)
+// space complexity: O(1)
+// Reference: https://en.wikipedia.org/wiki/Sorting_algorithm#Exchange_sort
+
+package sort
+
+import "github.com/TheAlgorithms/Go/constraints"
+
+func Exchange[T constraints.Ordered](arr []T) []T {
+	for i := 0; i < len(arr)-1; i++ {
+		for j := i + 1; j < len(arr); j++ {
+			if arr[i] > arr[j] {
+				arr[i], arr[j] = arr[j], arr[i]
+			}
+		}
+	}
+
+	return arr
+}

--- a/__code6/wavelet_tree.py
+++ b/__code6/wavelet_tree.py
@@ -1,0 +1,210 @@
+"""
+Wavelet tree is a data-structure designed to efficiently answer various range queries
+for arrays. Wavelets trees are different from other binary trees in the sense that
+the nodes are split based on the actual values of the elements and not on indices,
+such as the with segment trees or fenwick trees. You can read more about them here:
+1. https://users.dcc.uchile.cl/~jperez/papers/ioiconf16.pdf
+2. https://www.youtube.com/watch?v=4aSv9PcecDw&t=811s
+3. https://www.youtube.com/watch?v=CybAgVF-MMc&t=1178s
+"""
+
+from __future__ import annotations
+
+test_array = [2, 1, 4, 5, 6, 0, 8, 9, 1, 2, 0, 6, 4, 2, 0, 6, 5, 3, 2, 7]
+
+
+class Node:
+    def __init__(self, length: int) -> None:
+        self.minn: int = -1
+        self.maxx: int = -1
+        self.map_left: list[int] = [-1] * length
+        self.left: Node | None = None
+        self.right: Node | None = None
+
+    def __repr__(self) -> str:
+        """
+        >>> node = Node(length=27)
+        >>> repr(node)
+        'Node(min_value=-1 max_value=-1)'
+        >>> repr(node) == str(node)
+        True
+        """
+        return f"Node(min_value={self.minn} max_value={self.maxx})"
+
+
+def build_tree(arr: list[int]) -> Node | None:
+    """
+    Builds the tree for arr and returns the root
+    of the constructed tree
+
+    >>> build_tree(test_array)
+    Node(min_value=0 max_value=9)
+    """
+    root = Node(len(arr))
+    root.minn, root.maxx = min(arr), max(arr)
+    # Leaf node case where the node contains only one unique value
+    if root.minn == root.maxx:
+        return root
+    """
+    Take the mean of min and max element of arr as the pivot and
+    partition arr into left_arr and right_arr with all elements <= pivot in the
+    left_arr and the rest in right_arr, maintaining the order of the elements,
+    then recursively build trees for left_arr and right_arr
+    """
+    pivot = (root.minn + root.maxx) // 2
+
+    left_arr: list[int] = []
+    right_arr: list[int] = []
+
+    for index, num in enumerate(arr):
+        if num <= pivot:
+            left_arr.append(num)
+        else:
+            right_arr.append(num)
+        root.map_left[index] = len(left_arr)
+    root.left = build_tree(left_arr)
+    root.right = build_tree(right_arr)
+    return root
+
+
+def rank_till_index(node: Node | None, num: int, index: int) -> int:
+    """
+    Returns the number of occurrences of num in interval [0, index] in the list
+
+    >>> root = build_tree(test_array)
+    >>> rank_till_index(root, 6, 6)
+    1
+    >>> rank_till_index(root, 2, 0)
+    1
+    >>> rank_till_index(root, 1, 10)
+    2
+    >>> rank_till_index(root, 17, 7)
+    0
+    >>> rank_till_index(root, 0, 9)
+    1
+    """
+    if index < 0 or node is None:
+        return 0
+    # Leaf node cases
+    if node.minn == node.maxx:
+        return index + 1 if node.minn == num else 0
+    pivot = (node.minn + node.maxx) // 2
+    if num <= pivot:
+        # go the left subtree and map index to the left subtree
+        return rank_till_index(node.left, num, node.map_left[index] - 1)
+    else:
+        # go to the right subtree and map index to the right subtree
+        return rank_till_index(node.right, num, index - node.map_left[index])
+
+
+def rank(node: Node | None, num: int, start: int, end: int) -> int:
+    """
+    Returns the number of occurrences of num in interval [start, end] in the list
+
+    >>> root = build_tree(test_array)
+    >>> rank(root, 6, 3, 13)
+    2
+    >>> rank(root, 2, 0, 19)
+    4
+    >>> rank(root, 9, 2 ,2)
+    0
+    >>> rank(root, 0, 5, 10)
+    2
+    """
+    if start > end:
+        return 0
+    rank_till_end = rank_till_index(node, num, end)
+    rank_before_start = rank_till_index(node, num, start - 1)
+    return rank_till_end - rank_before_start
+
+
+def quantile(node: Node | None, index: int, start: int, end: int) -> int:
+    """
+    Returns the index'th smallest element in interval [start, end] in the list
+    index is 0-indexed
+
+    >>> root = build_tree(test_array)
+    >>> quantile(root, 2, 2, 5)
+    5
+    >>> quantile(root, 5, 2, 13)
+    4
+    >>> quantile(root, 0, 6, 6)
+    8
+    >>> quantile(root, 4, 2, 5)
+    -1
+    """
+    if index > (end - start) or start > end or node is None:
+        return -1
+    # Leaf node case
+    if node.minn == node.maxx:
+        return node.minn
+    # Number of elements in the left subtree in interval [start, end]
+    num_elements_in_left_tree = node.map_left[end] - (
+        node.map_left[start - 1] if start else 0
+    )
+    if num_elements_in_left_tree > index:
+        return quantile(
+            node.left,
+            index,
+            (node.map_left[start - 1] if start else 0),
+            node.map_left[end] - 1,
+        )
+    else:
+        return quantile(
+            node.right,
+            index - num_elements_in_left_tree,
+            start - (node.map_left[start - 1] if start else 0),
+            end - node.map_left[end],
+        )
+
+
+def range_counting(
+    node: Node | None, start: int, end: int, start_num: int, end_num: int
+) -> int:
+    """
+    Returns the number of elements in range [start_num, end_num]
+    in interval [start, end] in the list
+
+    >>> root = build_tree(test_array)
+    >>> range_counting(root, 1, 10, 3, 7)
+    3
+    >>> range_counting(root, 2, 2, 1, 4)
+    1
+    >>> range_counting(root, 0, 19, 0, 100)
+    20
+    >>> range_counting(root, 1, 0, 1, 100)
+    0
+    >>> range_counting(root, 0, 17, 100, 1)
+    0
+    """
+    if (
+        start > end
+        or node is None
+        or start_num > end_num
+        or node.minn > end_num
+        or node.maxx < start_num
+    ):
+        return 0
+    if start_num <= node.minn and node.maxx <= end_num:
+        return end - start + 1
+    left = range_counting(
+        node.left,
+        (node.map_left[start - 1] if start else 0),
+        node.map_left[end] - 1,
+        start_num,
+        end_num,
+    )
+    right = range_counting(
+        node.right,
+        start - (node.map_left[start - 1] if start else 0),
+        end - node.map_left[end],
+        start_num,
+        end_num,
+    )
+    return left + right
+
+
+if __name__ == "__main__":
+    import doctest
+
+    doctest.testmod()


### PR DESCRIPTION
8 Resolved the buffer overflow in the C++ FASTQ streamer by re-allocating the multiplexed header buffer dynamically based on adapter length. This prevents the 0x8F error when processing high-depth samples with non-standard metadata. Benchmark results show no significant impact on total throughput.