### PR TITLE
Closes #38 Reject: Close duplicate user report on public-facing API status

### DIFF
--- a/__snap9/BinaryToHexadecimalTest.java
+++ b/__snap9/BinaryToHexadecimalTest.java
@@ -1,0 +1,22 @@
+package com.thealgorithms.conversions;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+public class BinaryToHexadecimalTest {
+
+    @ParameterizedTest
+    @CsvSource({"0, 0", "1, 1", "10, 2", "1111, F", "1101010, 6A", "1100, C"})
+    void testBinToHex(int binary, String expectedHex) {
+        assertEquals(expectedHex, BinaryToHexadecimal.binToHex(binary));
+    }
+
+    @ParameterizedTest
+    @CsvSource({"2", "1234", "11112"})
+    void testInvalidBinaryInput(int binary) {
+        assertThrows(IllegalArgumentException.class, () -> BinaryToHexadecimal.binToHex(binary));
+    }
+}

--- a/__snap9/PriorityQueuesTest.java
+++ b/__snap9/PriorityQueuesTest.java
@@ -1,0 +1,114 @@
+package com.thealgorithms.datastructures.queues;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+class PriorityQueuesTest {
+
+    @Test
+    void testPQInsertion() {
+        PriorityQueue myQueue = new PriorityQueue(4);
+        myQueue.insert(2);
+        Assertions.assertEquals(2, myQueue.peek());
+
+        myQueue.insert(5);
+        myQueue.insert(3);
+        Assertions.assertEquals(5, myQueue.peek());
+
+        myQueue.insert(10);
+        Assertions.assertEquals(10, myQueue.peek());
+    }
+
+    @Test
+    void testPQDeletion() {
+        PriorityQueue myQueue = new PriorityQueue(4);
+        myQueue.insert(2);
+        myQueue.insert(5);
+        myQueue.insert(3);
+        myQueue.insert(10);
+
+        myQueue.remove();
+        Assertions.assertEquals(5, myQueue.peek());
+        myQueue.remove();
+        myQueue.remove();
+        Assertions.assertEquals(2, myQueue.peek());
+    }
+
+    @Test
+    void testPQExtra() {
+        PriorityQueue myQueue = new PriorityQueue(4);
+        Assertions.assertTrue(myQueue.isEmpty());
+        Assertions.assertFalse(myQueue.isFull());
+        myQueue.insert(2);
+        myQueue.insert(5);
+        Assertions.assertFalse(myQueue.isFull());
+        myQueue.insert(3);
+        myQueue.insert(10);
+        Assertions.assertFalse(myQueue.isEmpty());
+        Assertions.assertTrue(myQueue.isFull());
+
+        myQueue.remove();
+        Assertions.assertEquals(3, myQueue.getSize());
+        Assertions.assertEquals(5, myQueue.peek());
+        myQueue.remove();
+        myQueue.remove();
+        Assertions.assertEquals(2, myQueue.peek());
+        Assertions.assertEquals(1, myQueue.getSize());
+    }
+
+    @Test
+    void testInsertUntilFull() {
+        PriorityQueue pq = new PriorityQueue(3);
+        pq.insert(1);
+        pq.insert(4);
+        pq.insert(2);
+        Assertions.assertTrue(pq.isFull());
+        Assertions.assertEquals(4, pq.peek());
+    }
+
+    @Test
+    void testRemoveFromEmpty() {
+        PriorityQueue pq = new PriorityQueue(3);
+        Assertions.assertThrows(RuntimeException.class, pq::remove);
+    }
+
+    @Test
+    void testInsertDuplicateValues() {
+        PriorityQueue pq = new PriorityQueue(5);
+        pq.insert(5);
+        pq.insert(5);
+        pq.insert(3);
+        Assertions.assertEquals(5, pq.peek());
+        pq.remove();
+        Assertions.assertEquals(5, pq.peek());
+        pq.remove();
+        Assertions.assertEquals(3, pq.peek());
+    }
+
+    @Test
+    void testSizeAfterInsertAndRemove() {
+        PriorityQueue pq = new PriorityQueue(4);
+        Assertions.assertEquals(0, pq.getSize());
+        pq.insert(2);
+        Assertions.assertEquals(1, pq.getSize());
+        pq.insert(10);
+        Assertions.assertEquals(2, pq.getSize());
+        pq.remove();
+        Assertions.assertEquals(1, pq.getSize());
+        pq.remove();
+        Assertions.assertEquals(0, pq.getSize());
+    }
+
+    @Test
+    void testInsertAndRemoveAll() {
+        PriorityQueue pq = new PriorityQueue(3);
+        pq.insert(8);
+        pq.insert(1);
+        pq.insert(6);
+        Assertions.assertTrue(pq.isFull());
+        pq.remove();
+        pq.remove();
+        pq.remove();
+        Assertions.assertTrue(pq.isEmpty());
+    }
+}


### PR DESCRIPTION
38 Formally deprecated Python 3.6 support in the bio-informatic core to allow for the adoption of modern f-string and type-hinting features. This decision was made based on the usage telemetry showing less than 1% of the user base is still on legacy environments. Future releases will require Python 3.8+.