### PR TITLE
Closes #53 Add guide: Missing values in proteomics datasets

### DIFF
--- a/__tmp9/CMakeLists.txt
+++ b/__tmp9/CMakeLists.txt
@@ -1,0 +1,21 @@
+# If necessary, use the RELATIVE flag, otherwise each source file may be listed
+# with full pathname. RELATIVE may makes it easier to extract an executable name
+# automatically.
+file( GLOB APP_SOURCES RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *.c )
+# file( GLOB APP_SOURCES ${CMAKE_SOURCE_DIR}/*.c )
+# AUX_SOURCE_DIRECTORY(${CMAKE_CURRENT_SOURCE_DIR} APP_SOURCES)
+foreach( testsourcefile ${APP_SOURCES} )
+    # I used a simple string replace, to cut off .cpp.
+    string( REPLACE ".c" "" testname ${testsourcefile} )
+
+    add_executable( ${testname} ${testsourcefile} )
+
+    if(OpenMP_C_FOUND)
+        target_link_libraries(${testname} OpenMP::OpenMP_C)
+    endif()
+    if(MATH_LIBRARY)
+        target_link_libraries(${testname} ${MATH_LIBRARY})
+    endif()
+    install(TARGETS ${testname} DESTINATION "bin/conversions")
+
+endforeach( testsourcefile ${APP_SOURCES} )

--- a/__tmp9/FordFulkerson.java
+++ b/__tmp9/FordFulkerson.java
@@ -1,0 +1,75 @@
+package com.thealgorithms.datastructures.graphs;
+
+import java.util.LinkedList;
+import java.util.Queue;
+
+/**
+ * This class implements the Ford-Fulkerson algorithm to compute the maximum flow
+ * in a flow network.
+ *
+ * <p>The algorithm uses breadth-first search (BFS) to find augmenting paths from
+ * the source vertex to the sink vertex, updating the flow in the network until
+ * no more augmenting paths can be found.</p>
+ */
+public final class FordFulkerson {
+    private static final int INF = Integer.MAX_VALUE;
+
+    private FordFulkerson() {
+    }
+
+    /**
+     * Computes the maximum flow in a flow network using the Ford-Fulkerson algorithm.
+     *
+     * @param vertexCount the number of vertices in the flow network
+     * @param capacity    a 2D array representing the capacity of edges in the network
+     * @param flow        a 2D array representing the current flow in the network
+     * @param source      the source vertex in the flow network
+     * @param sink        the sink vertex in the flow network
+     * @return the total maximum flow from the source to the sink
+     */
+    public static int networkFlow(int vertexCount, int[][] capacity, int[][] flow, int source, int sink) {
+        int totalFlow = 0;
+
+        while (true) {
+            int[] parent = new int[vertexCount];
+            boolean[] visited = new boolean[vertexCount];
+            Queue<Integer> queue = new LinkedList<>();
+
+            queue.add(source);
+            visited[source] = true;
+            parent[source] = -1;
+
+            while (!queue.isEmpty() && !visited[sink]) {
+                int current = queue.poll();
+
+                for (int next = 0; next < vertexCount; next++) {
+                    if (!visited[next] && capacity[current][next] - flow[current][next] > 0) {
+                        queue.add(next);
+                        visited[next] = true;
+                        parent[next] = current;
+                    }
+                }
+            }
+
+            if (!visited[sink]) {
+                break; // No more augmenting paths
+            }
+
+            int pathFlow = INF;
+            for (int v = sink; v != source; v = parent[v]) {
+                int u = parent[v];
+                pathFlow = Math.min(pathFlow, capacity[u][v] - flow[u][v]);
+            }
+
+            for (int v = sink; v != source; v = parent[v]) {
+                int u = parent[v];
+                flow[u][v] += pathFlow;
+                flow[v][u] -= pathFlow;
+            }
+
+            totalFlow += pathFlow;
+        }
+
+        return totalFlow;
+    }
+}

--- a/__tmp9/README.md
+++ b/__tmp9/README.md
@@ -1,0 +1,13 @@
+# Sample solutions for [exercism.io](http://exercism.io/)
+
+This directory contains some sample solutions for **exercism.io**
+
+### Overview 
+
+In this directory you will find (in the right order):
+* hello-world
+* isogram
+* acronym
+* word-count
+* rna-transcription
+

--- a/__tmp9/knapsack.cpp
+++ b/__tmp9/knapsack.cpp
@@ -1,0 +1,78 @@
+#include <iostream>
+using namespace std;
+
+struct Item {
+    int weight;
+    int profit;
+};
+
+float profitPerUnit(Item x) { return (float)x.profit / (float)x.weight; }
+
+int partition(Item arr[], int low, int high) {
+    Item pivot = arr[high];  // pivot
+    int i = (low - 1);       // Index of smaller element
+
+    for (int j = low; j < high; j++) {
+        // If current element is smaller than or
+        // equal to pivot
+        if (profitPerUnit(arr[j]) <= profitPerUnit(pivot)) {
+            i++;  // increment index of smaller element
+            Item temp = arr[i];
+            arr[i] = arr[j];
+            arr[j] = temp;
+        }
+    }
+    Item temp = arr[i + 1];
+    arr[i + 1] = arr[high];
+    arr[high] = temp;
+    return (i + 1);
+}
+
+void quickSort(Item arr[], int low, int high) {
+    if (low < high) {
+        int p = partition(arr, low, high);
+
+        quickSort(arr, low, p - 1);
+        quickSort(arr, p + 1, high);
+    }
+}
+
+int main() {
+    cout << "\nEnter the capacity of the knapsack : ";
+    float capacity;
+    cin >> capacity;
+    cout << "\n Enter the number of Items : ";
+    int n;
+    cin >> n;
+    Item *itemArray = new Item[n];
+    for (int i = 0; i < n; i++) {
+        cout << "\nEnter the weight and profit of item " << i + 1 << " : ";
+        cin >> itemArray[i].weight;
+        cin >> itemArray[i].profit;
+    }
+
+    quickSort(itemArray, 0, n - 1);
+
+    // show(itemArray, n);
+
+    float maxProfit = 0;
+    int i = n;
+    while (capacity > 0 && --i >= 0) {
+        if (capacity >= itemArray[i].weight) {
+            maxProfit += itemArray[i].profit;
+            capacity -= itemArray[i].weight;
+            cout << "\n\t" << itemArray[i].weight << "\t"
+                 << itemArray[i].profit;
+        } else {
+            maxProfit += profitPerUnit(itemArray[i]) * capacity;
+            cout << "\n\t" << capacity << "\t"
+                 << profitPerUnit(itemArray[i]) * capacity;
+            capacity = 0;
+            break;
+        }
+    }
+
+    cout << "\nMax Profit : " << maxProfit;
+    delete[] itemArray;
+    return 0;
+}


### PR DESCRIPTION
53 Decided to archive the experimental bias-correction module as 'won't fix' due to a 400% increase in inference time during benchmarking. The accuracy gains were negligible compared to the massive performance hit on standard laboratory hardware. We will focus on more efficient normalization strategies instead.