### PR TITLE
Closes #60 Fix: Populate missing parameter descriptions in codon docstrings

### DIFF
--- a/__dev_src7/cll.h
+++ b/__dev_src7/cll.h
@@ -1,0 +1,43 @@
+/*
+ * Simple data structure CLL (Circular Linear Linked List)
+ * */
+#include <cctype>
+#include <cstdlib>
+#include <cstring>
+#include <iostream>
+
+#ifndef CLL_H
+#define CLL_H
+/*The data structure is a linear linked list of integers */
+struct node {
+    int data;
+    node* next;
+};
+
+class cll {
+ public:
+    cll(); /* Construct without parameter */
+    ~cll();
+    void display(); /* Show the list */
+
+    /******************************************************
+     * Useful method for list
+     *******************************************************/
+    void insert_front(int new_data);  /* Insert a new value at head  */
+    void insert_tail(int new_data);   /* Insert a new value at tail */
+    int get_size();                   /* Get total element in list */
+    bool find_item(int item_to_find); /* Find an item in list */
+
+    /******************************************************
+     * Overloading method for list
+     *******************************************************/
+    int operator*(); /* Returns the info contained in head */
+    /* Overload the pre-increment operator.
+       The iterator is advanced to the next node. */
+    void operator++();
+
+ protected:
+    node* head;
+    int total; /* Total element in a list */
+};
+#endif

--- a/__dev_src7/jump2.go
+++ b/__dev_src7/jump2.go
@@ -1,0 +1,24 @@
+package search
+
+import "math"
+
+func Jump2(arr []int, target int) (int, error) {
+	step := int(math.Round(math.Sqrt(float64(len(arr)))))
+	rbound := len(arr)
+	for i := step; i < len(arr); i += step {
+		if arr[i] > target {
+			rbound = i
+			break
+		}
+	}
+
+	for i := rbound - step; i < rbound; i++ {
+		if arr[i] == target {
+			return i, nil
+		}
+		if arr[i] > target {
+			break
+		}
+	}
+	return -1, ErrNotFound
+}


### PR DESCRIPTION
60 This change exposes retry policy configuration via existing settings. Users can now tune robustness based on their environment. Defaults remain conservative.