### PR TITLE
Closes #64 Clarify intended usage of dry-run execution mode

### DIFF
--- a/__dev7/PascalTriangleTest.java
+++ b/__dev7/PascalTriangleTest.java
@@ -1,0 +1,51 @@
+package com.thealgorithms.maths;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+
+import org.junit.jupiter.api.Test;
+
+class PascalTriangleTest {
+
+    @Test
+    void testForOne() {
+        int[][] result = PascalTriangle.pascal(1);
+        int[][] expected = {{1}};
+        assertArrayEquals(result, expected);
+    }
+
+    @Test
+    void testForTwo() {
+        int[][] result = PascalTriangle.pascal(2);
+        int[][] expected = {{1, 0}, {1, 1}};
+        assertArrayEquals(result, expected);
+    }
+
+    @Test
+    void testForFive() {
+        int[][] result = PascalTriangle.pascal(5);
+        int[][] expected = {
+            {1, 0, 0, 0, 0},
+            {1, 1, 0, 0, 0},
+            {1, 2, 1, 0, 0},
+            {1, 3, 3, 1, 0},
+            {1, 4, 6, 4, 1},
+        };
+        assertArrayEquals(result, expected);
+    }
+
+    @Test
+    void testForEight() {
+        int[][] result = PascalTriangle.pascal(8);
+        int[][] expected = {
+            {1, 0, 0, 0, 0, 0, 0, 0},
+            {1, 1, 0, 0, 0, 0, 0, 0},
+            {1, 2, 1, 0, 0, 0, 0, 0},
+            {1, 3, 3, 1, 0, 0, 0, 0},
+            {1, 4, 6, 4, 1, 0, 0, 0},
+            {1, 5, 10, 10, 5, 1, 0, 0},
+            {1, 6, 15, 20, 15, 6, 1, 0},
+            {1, 7, 21, 35, 35, 21, 7, 1},
+        };
+        assertArrayEquals(expected, result);
+    }
+}

--- a/__dev7/gray_code.cpp
+++ b/__dev7/gray_code.cpp
@@ -1,0 +1,113 @@
+/**
+ * @brief Program to generate n-bit [Gray 
+ * code](https://en.wikipedia.org/wiki/Gray_code)
+ * 
+ * @details
+ * Gray code is a binary numeral system
+ * where consecutive values differ in exactly 1 bit.
+ * The following code offers one of many possible Gray codes 
+ * given some pre-determined number of bits.
+ */
+
+#include <bitset>  /// for gray code representation
+#include <cassert>  /// for assert
+#include <iostream>  /// for IO operations
+#include <vector>  /// for vector data structure
+
+/**
+ * @namespace bit_manipulation
+ * @brief Bit manipulation algorithms
+ */
+namespace bit_manipulation {
+/**
+ * @namespace gray_code
+ * @brief Generate n-bit Gray code
+ */
+namespace gray_code {
+/**
+ * @brief The main function to generate n-bit Gray code
+ *
+ * @param n Number of bits
+ * @return A vector that stores the n-bit Gray code
+ */
+std::vector<std::bitset<32>> gray_code_generation(int n) {
+    std::vector<std::bitset<32>> gray_code = {};  // Initialise empty vector
+
+    // No Gray codes for non-positive values of n
+    if (n <= 0) {
+        return gray_code;
+    }
+    
+    int total_codes = 1 << n;  // Number of n-bit gray codes
+
+    for (int i = 0; i < total_codes; i++) {
+        int gray_num = i ^ (i >> 1);  // Gray code formula
+        gray_code.push_back(std::bitset<32>(gray_num));  // Store the value
+    }
+
+    return gray_code;
+} 
+}  // namespace gray_code
+}  // namespace bit_manipulation
+
+/**
+ * @brief Self-test implementation
+ *
+ * @returns void
+ */
+static void test() { 
+    std::vector<std::bitset<32>> gray_code_negative_1 = {};
+
+    std::vector<std::bitset<32>> gray_code_0 = {};
+
+    std::vector<std::bitset<32>> gray_code_1 = {
+        std::bitset<32>(0), std::bitset<32>(1)
+    };
+
+    std::vector<std::bitset<32>> gray_code_2 = {
+        std::bitset<32>(0), std::bitset<32>(1), std::bitset<32>(3), std::bitset<32>(2)
+    };
+
+    std::vector<std::bitset<32>> gray_code_3 = {
+        std::bitset<32>(0), std::bitset<32>(1), std::bitset<32>(3), std::bitset<32>(2),
+        std::bitset<32>(6), std::bitset<32>(7), std::bitset<32>(5), std::bitset<32>(4)
+    };
+
+    std::vector<std::bitset<32>> gray_code_4 = {
+        std::bitset<32>(0), std::bitset<32>(1), std::bitset<32>(3), std::bitset<32>(2),
+        std::bitset<32>(6), std::bitset<32>(7), std::bitset<32>(5), std::bitset<32>(4),
+        std::bitset<32>(12), std::bitset<32>(13), std::bitset<32>(15), std::bitset<32>(14),
+        std::bitset<32>(10), std::bitset<32>(11), std::bitset<32>(9), std::bitset<32>(8)
+    };
+
+    std::vector<std::bitset<32>> gray_code_5 = {
+        std::bitset<32>(0), std::bitset<32>(1), std::bitset<32>(3), std::bitset<32>(2),
+        std::bitset<32>(6), std::bitset<32>(7), std::bitset<32>(5), std::bitset<32>(4),
+        std::bitset<32>(12), std::bitset<32>(13), std::bitset<32>(15), std::bitset<32>(14),
+        std::bitset<32>(10), std::bitset<32>(11), std::bitset<32>(9), std::bitset<32>(8),
+        std::bitset<32>(24), std::bitset<32>(25), std::bitset<32>(27), std::bitset<32>(26),
+        std::bitset<32>(30), std::bitset<32>(31), std::bitset<32>(29), std::bitset<32>(28),
+        std::bitset<32>(20), std::bitset<32>(21), std::bitset<32>(23), std::bitset<32>(22),
+        std::bitset<32>(18), std::bitset<32>(19), std::bitset<32>(17), std::bitset<32>(16)
+    };
+
+    // invalid values for n
+    assert(bit_manipulation::gray_code::gray_code_generation(-1) == gray_code_negative_1);
+    assert(bit_manipulation::gray_code::gray_code_generation(0) == gray_code_0);
+
+    // valid values for n
+    assert(bit_manipulation::gray_code::gray_code_generation(1) == gray_code_1);
+    assert(bit_manipulation::gray_code::gray_code_generation(2) == gray_code_2);
+    assert(bit_manipulation::gray_code::gray_code_generation(3) == gray_code_3);
+    assert(bit_manipulation::gray_code::gray_code_generation(4) == gray_code_4);
+    assert(bit_manipulation::gray_code::gray_code_generation(5) == gray_code_5);
+}
+
+/**
+ * @brief Main function
+ * @returns 0 on exit
+ */
+int main() {
+    test();  //Run self-test implementation
+    return 0;
+}

--- a/__dev7/longest_substring_without_repeating_characters.cpp
+++ b/__dev7/longest_substring_without_repeating_characters.cpp
@@ -1,0 +1,110 @@
+/**
+ * @file
+ * @brief Solution for Longest Substring Without Repeating Characters problem.
+ * @details
+ * Problem link: https://leetcode.com/problems/longest-substring-without-repeating-characters/description/
+ * 
+ * Intuition:
+ * 1) The intuition is straightforward and simple. We track the frequency of characters.
+ * 2) Since we can't use a string to track the longest substring without repeating characters efficiently (as removing a character from the front of a string isn't O(1)), we optimize the solution using a deque approach.
+ *
+ * Approach:
+ * 1) Initialize an unordered_map to track the frequency of characters.
+ * 2) Use a deque for pushing characters, and update the result deque (`res`) with the current deque (`temp`) 
+ *    whenever we find a longer substring.
+ * 3) Use a while loop to reduce the frequency from the front, incrementing `i`, 
+ *    and removing characters from the `temp` deque as we no longer need them.
+ * 4) Return `res.size()` as we are interested in the length of the longest substring.
+ * 
+ * Time Complexity: O(N)
+ * Space Complexity: O(N)
+ * 
+ * I hope this helps to understand.
+ * Thank you!
+ * @author [Ashish Kumar Sahoo](github.com/ashish5kmax)
+ **/
+
+#include <iostream>        // for IO Operations
+#include <unordered_map>   // for std::unordered_map
+#include <deque>           // for std::deque
+#include <string>          // for string class/string datatype which is taken as input
+#include <cassert>         // for assert
+
+/**
+ * @class Longest_Substring
+ * @brief Class that solves the Longest Substring Without Repeating Characters problem.
+ */
+class Longest_Substring {
+public:
+    /**
+     * @brief Function to find the length of the longest substring without repeating characters.
+     * @param s Input string.
+     * @return Length of the longest substring.
+     */
+    int lengthOfLongestSubstring(std::string s) {
+        // If the size of string is 1, then it will be the answer.
+        if (s.size() == 1) return 1;
+
+        // Map used to store the character frequency.
+        std::unordered_map<char, int> m;
+        int n = s.length();
+
+        // Deque to remove from back if repeating characters are present.
+        std::deque<char> temp;
+        std::deque<char> res;
+        int i, j;
+
+        // Sliding window approach using two pointers.
+        for (i = 0, j = 0; i < n && j < n;) {
+            m[s[j]]++;
+
+            // If repeating character found, update result and remove from the front.
+            if (m[s[j]] > 1) {
+                if (temp.size() > res.size()) {
+                    res = temp;
+                }
+
+                while (m[s[j]] > 1) {
+                    temp.pop_front();
+                    m[s[i]]--;
+                    i++;
+                }
+            }
+
+            // Add the current character to the deque.
+            temp.push_back(s[j]);
+            j++;
+        }
+
+        // Final check to update result.
+        if (temp.size() > res.size()) {
+            res = temp;
+        }
+
+        return res.size();  // Return the length of the longest substring.
+    }
+};
+
+/**
+ * @brief Self-test implementations
+ * @returns void
+ */
+static void tests() {
+    Longest_Substring soln;
+    assert(soln.lengthOfLongestSubstring("abcabcbb") == 3);
+    assert(soln.lengthOfLongestSubstring("bbbbb") == 1);
+    assert(soln.lengthOfLongestSubstring("pwwkew") == 3);
+    assert(soln.lengthOfLongestSubstring("") == 0); // Test case for empty string
+    assert(soln.lengthOfLongestSubstring("abcdef") == 6); // Test case for all unique characters
+    assert(soln.lengthOfLongestSubstring("a") == 1); // Single character
+    std::cout << "All test cases passed!" << std::endl;
+}
+
+/**
+ * @brief Main function.
+ * @return 0 on successful execution.
+ */
+int main() {
+    tests(); // run self-test implementations
+    return 0;
+}

--- a/__dev7/newton_method.dart
+++ b/__dev7/newton_method.dart
@@ -1,0 +1,35 @@
+import 'dart:math';
+
+/// Approximate derivative of [f] at [x]
+double derivative(double Function(double) f, double x, [double h = 1e-10]) {
+  return (f(x + h) - f(x - h)) / (2 * h);
+}
+
+/// Find root of given [f] (x where [f(x)] == 0)
+double findRoot(double Function(double) f,
+    [double initialValue = 0, int iterations = 10, double h = 1e-10]) {
+  double currentValue = initialValue;
+  for (int i = 0; i < iterations; i++) {
+    currentValue -= f(currentValue) / derivative(f, currentValue);
+  }
+
+  return currentValue;
+}
+
+double f(x) {
+  return 2 * x + 4;
+}
+
+double g(x) {
+  return 2 * pow(x, 2) + 7 * x + 1;
+}
+
+main() {
+  double fRoot = findRoot(f);
+  double gRoot = findRoot(g);
+  double sinRoot = findRoot(sin, 10);
+
+  print("f(x) = 2x + 4, f($fRoot) = ${f(fRoot)}");
+  print("g(x) = 2x^2 + 7x + 1, g($gRoot) = ${g(gRoot)}");
+  print("sin(${sinRoot / pi} * pi) = ${sin(sinRoot)}");
+}


### PR DESCRIPTION
64 Decided to archive the experimental bias-correction module as 'won't fix' due to a 400% increase in inference time during benchmarking. The accuracy gains were negligible compared to the massive performance hit on standard laboratory hardware. We will focus on more efficient normalization strategies instead.